### PR TITLE
Enable scrolling over discovered wifi and bluetooth devices.

### DIFF
--- a/app/src/main/res/layout/fragment_scan.xml
+++ b/app/src/main/res/layout/fragment_scan.xml
@@ -20,30 +20,44 @@
         app:layout_constraintTop_toTopOf="parent" />
 
     <TextView
-        android:id="@+id/btDevices"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
-        android:maxLines="12"
-        android:minLines="12"
-        android:scrollbars="vertical"
+        android:id="@+id/btDeviceCount"
+        app:layout_constraintTop_toBottomOf="@id/gpsCoords"
+        android:layout_width="match_parent"
+        android:layout_height="20dp"
         android:text="@string/btdevices_0"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/gpsCoords" />
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="10dp"
+        android:layout_marginBottom="10dp"/>
+
+    <ListView
+        android:id="@+id/btDevices"
+        app:layout_constraintTop_toBottomOf="@id/btDeviceCount"
+        android:layout_width="match_parent"
+        android:layout_height="100dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginEnd="8dp"
+        android:paddingTop="10dp"
+        android:paddingBottom="10dp"/>
 
     <TextView
-        android:id="@+id/wifiDevices"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
-        android:maxLines="15"
-        android:minLines="15"
-        android:scrollbars="vertical"
+        android:id="@+id/wifiDeviceCount"
+        app:layout_constraintTop_toBottomOf="@+id/btDevices"
+        android:layout_width="match_parent"
+        android:layout_height="20dp"
         android:text="@string/wifidevices_0"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/btDevices" />
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="10dp"
+        android:layout_marginBottom="10dp"/>
+
+    <ListView
+        android:id="@+id/wifiDevices"
+        app:layout_constraintTop_toBottomOf="@id/wifiDeviceCount"
+        android:layout_width="match_parent"
+        android:layout_height="100dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginEnd="8dp"
+        android:paddingTop="10dp"
+        android:paddingBottom="10dp" />
 
     <TextView
         android:id="@+id/txtRecords"
@@ -98,7 +112,7 @@
             android:id="@+id/btnPause"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="PAUSE"
+            android:text="@string/pause"
             tools:layout_editor_absoluteX="265dp"
             tools:layout_editor_absoluteY="620dp" />
     </LinearLayout>

--- a/app/src/main/res/layout/small_text_list_view.xml
+++ b/app/src/main/res/layout/small_text_list_view.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@android:id/text1"
+    android:paddingTop="2dip"
+    android:paddingBottom="3dip"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:textSize="12sp" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,4 +12,5 @@
     <string name="decline">Decline</string>
     <string name="accept">Accept</string>
     <string name="privacy_policy">Privacy Policy</string>
+    <string name="pause">PAUSE</string>
 </resources>


### PR DESCRIPTION
This pull request would enable users to view all the devices they scan for by scrolling through them.

It also puts the "PAUSE" where the other string are kept for because Android Studios was complaining.

Manual testing was done and can be shown within the zip file (a screenshot of the new layout may be viewed along with a video of my scrolling around and showing functionality is not broken)

The listview's for the bluetooth and wifi devices pull from the template xml `app/src/main/res/layout/small_text_list_view.xml` to have smaller text. In theory this could be expanded to make the layout nicer have separate entries for the DB and name and whatnot.

Also I had to remove firebase and crashylitics from my application because I don't have the relevent key to link it (which makes sense I think). I don't think this will break it but I can't test it easily.

I also provided the apk. Feel free to use it if you really need and are too lazy to compile it lol.

[screenshot_test_and_apk_without_firebase.zip](https://github.com/compscidr/awm-lib-example/files/3100391/screenshot_test_and_apk_without_firebase.zip)

