### PR TITLE
changed the layout of the privacy policy screen to be nicer on the eyes

### DIFF
--- a/app/src/main/java/io/rightmesh/awm_lib_example/PrivacyPolicyActivity.java
+++ b/app/src/main/java/io/rightmesh/awm_lib_example/PrivacyPolicyActivity.java
@@ -2,6 +2,7 @@ package io.rightmesh.awm_lib_example;
 
 import android.app.Activity;
 import android.content.SharedPreferences;
+import android.graphics.Color;
 import android.os.Bundle;
 import android.support.v7.preference.PreferenceManager;
 import android.view.View;
@@ -16,6 +17,7 @@ public class PrivacyPolicyActivity extends Activity {
         setContentView(R.layout.activity_privacy_policy);
 
         web = findViewById(R.id.webView);
+        web.setBackgroundColor(Color.TRANSPARENT);
         web.loadUrl("file:///android_asset/privacy_policy.html");
     }
 

--- a/app/src/main/res/drawable/rounded_corner_accept.xml
+++ b/app/src/main/res/drawable/rounded_corner_accept.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- modified from:
+https://www.viralandroid.com/2015/11/make-rounded-corners-in-android-layout.html
+-->
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/accept" />
+    <stroke
+        android:width="1dp" />
+    <corners android:radius="4dp" />
+</shape>

--- a/app/src/main/res/drawable/rounded_corner_decline.xml
+++ b/app/src/main/res/drawable/rounded_corner_decline.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- modified from:
+https://www.viralandroid.com/2015/11/make-rounded-corners-in-android-layout.html
+-->
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/decline" />
+    <stroke
+        android:width="1dp" />
+    <corners android:radius="4dp" />
+</shape>

--- a/app/src/main/res/drawable/rounded_corner_policy.xml
+++ b/app/src/main/res/drawable/rounded_corner_policy.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- modified from:
+https://www.viralandroid.com/2015/11/make-rounded-corners-in-android-layout.html
+-->
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/gentleGreen" />
+    <stroke android:width="1dp" />
+    <corners android:radius="10dp" />
+</shape>

--- a/app/src/main/res/layout/activity_privacy_policy.xml
+++ b/app/src/main/res/layout/activity_privacy_policy.xml
@@ -4,39 +4,48 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:padding="4dp"
+    android:background="@color/backgroundGreen"
     tools:context=".PrivacyPolicyActivity">
 
+    <FrameLayout
+        android:id="@+id/frame"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@drawable/rounded_corner_policy">
+        <WebView
+            android:id="@+id/webView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintBottom_toTopOf="@+id/btnAccept"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:layout_editor_absoluteX="86dp"
+            android:layout_marginBottom="80dp">
+        </WebView>
+    </FrameLayout>
     <Button
+        android:background="@drawable/rounded_corner_accept"
         android:id="@+id/btnAccept"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="8dp"
+        android:layout_marginEnd="20dp"
         android:layout_marginBottom="8dp"
         android:onClick="accept"
         android:text="@string/accept"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent" />
-
-    <WebView
-        android:id="@+id/webView"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="8dp"
-        app:layout_constraintBottom_toTopOf="@+id/btnAccept"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:ignore="MissingConstraints"
-        tools:layout_editor_absoluteX="86dp">
-
-    </WebView>
+        app:layout_constraintEnd_toEndOf="parent"
+        android:textColor="#FFFFFF"/>
 
     <Button
         android:id="@+id/btnDecline"
+        android:background="@drawable/rounded_corner_decline"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="8dp"
+        android:layout_marginStart="20dp"
         android:layout_marginBottom="8dp"
         android:onClick="decline"
         android:text="@string/decline"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent" />
+        app:layout_constraintStart_toStartOf="parent"
+        android:textColor="#FFFFFF"/>
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -3,4 +3,8 @@
     <color name="colorPrimary">#008577</color>
     <color name="colorPrimaryDark">#00574B</color>
     <color name="colorAccent">#D81B60</color>
+    <color name="backgroundGreen">#A9F5A9</color>
+    <color name="gentleGreen">#DAFFE5</color>
+    <color name="accept">#16A92E</color>
+    <color name="decline">#CD6B6C</color>
 </resources>


### PR DESCRIPTION
This pull request just makes the privacy policy look cleaner. It does switch the order of the buttons as well. Take a look in the zip attached to see what it would look like now.

[new_privacy_policy_artifacts.zip](https://github.com/compscidr/awm-lib-example/files/3100475/new_privacy_policy_artifacts.zip)
